### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-#xcparse
+# xcparse
 
 xcparse is a python library for parsing and working with Xcode workspace and project files.
 
-##Support
+## Support
 
 xcparse supports all modern objects found in xcodeproj files, and many legacy object. The parsing component of this library is complete and production ready. There are additional features that I am adding to make complex operations, such as resolving dependency build ordering, easy to perform.
 
 
-##Examples
+## Examples
 
 Loading a project or workspace
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
